### PR TITLE
Fix voicemail defaulting to empty password

### DIFF
--- a/views/quickCreate.php
+++ b/views/quickCreate.php
@@ -1,3 +1,8 @@
+<?php
+$devs = \FreePBX::Core()->getAllUsersByDeviceType();
+$dev = end($devs);
+$startExt = $dev['extension'] + 1;
+?>
 <div class="element-container">
 	<div class="row">
 		<div class="form-group">


### PR DESCRIPTION
Resolves [FREEPBX-13465](http://issues.freepbx.org/browse/FREEPBX-13465). Not sure if this is the best way to do it; it seems heavy on the DB, but better than a global variable! Probably an ideal solution would be a method in core that just give you the result of `SELECT MAX(extension)+1 FROM users`
