### PR TITLE
voicemail: updated maxsilence description and tooltip to reflect seconds instead of milliseconds.

### DIFF
--- a/Voicemail.class.php
+++ b/Voicemail.class.php
@@ -2451,8 +2451,8 @@ class Voicemail extends FreePBX_Helpers implements BMO {
 						"type" => "number",
 						"options" => array("1","9999"),
 						"default" => '10',
-						"description" => _("Max Message Silence (Milliseconds)"),
-						"helptext" => _("How many milliseconds of silence before we end the recording (in milliseconds).")."  <a href='https://issues.freepbx.org/browse/FREEPBX-10998' target='_blank'>"._("Why is this in milliseconds?")."</a> [maxsilence]"
+						"description" => _("Max Message Silence (Seconds)"),
+						"helptext" => _("How many seconds of silence before we end the recording.")." [maxsilence]"
 					),
 					"silencethreshold" => array(
 						"level" => array("general"),


### PR DESCRIPTION
Fix FreePBX/issue-tracker#606