### PR TITLE
Isssue-629 Recent Scribe UCP Icon fix causes uncaught Type Error : transcriptionURL

### DIFF
--- a/ucp/assets/js/global.js
+++ b/ucp/assets/js/global.js
@@ -894,7 +894,7 @@ var VoicemailC = UCPMC.extend({
 
 		html += '<a class="delete" alt="'+_('Delete')+'" data-id="'+row.msg_id+'"><i class="fa fa-trash-o"></i></a>';
 
-		if(row.converttotext.transcriptionURL !== undefined && row.converttotext.transcriptionURL !== null && row.converttotext.transcriptionURL != '' && settings.isScribeEnabled) {
+		if((row.converttotext !== undefined) && row.converttotext.transcriptionURL !== undefined && row.converttotext.transcriptionURL !== null && row.converttotext.transcriptionURL != '' && settings.isScribeEnabled) {
 			html += '<a href="#" data-toggle="tooltip" class="transcript tool-tip" title="Read the voice transcription" title="Read the voice transcription" onclick="openmodal(\'' + UCP.ajaxUrl +row.converttotext.transcriptionURL + '\')"> <img src="'+row.converttotext.scribeIconURL+'" width="15px" height="15px" alt="PBX Scribe" /></a>';
 		}
 		return html;


### PR DESCRIPTION
Issue: When we add a widget in UCP like voicemail and scribe is not installed, we get the error in UCP 
(uncaught Type Error: transcriptionURL). 

This PR will fix this error.

Fix for 15V+