### PR TITLE
Voicemail: Add option to lock the password (i.e. for shared mailboxes)

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -320,7 +320,7 @@ function voicemail_configpageinit($pagename) {
 
 		// JS for verifying an empty password is OK
 		$msg = _('Voicemail is enabled but the Voicemail Password field is empty.  Are you sure you wish to continue?');
-		$js = 'if(theForm.vmpwd.value.match(/^[0-9A-D\*#]*$/i)) {return true;}else{return false;}';
+		$js = 'if(theForm.vmpwd.value.match(/^\-{0,1}[0-9A-D\*#]+$/i)) {return true;}else{return false;}';
 		$js = 'if (theForm.vmpwd.value == "") { if(confirm("'.$msg.'")) { return true } else { return false; }} else { '.$js.' };';
 		$currentcomponent->addjsfunc('isValidVoicemailPass(notused)', $js);
 
@@ -495,7 +495,7 @@ function voicemail_configpageload() {
 
 		$fc_vm = featurecodes_getFeatureCode('voicemail', 'dialvoicemail');
 
-		$msgInvalidVmPwd = _("Please enter a valid Voicemail Password, using digits only");
+		$msgInvalidVmPwd = _("Please enter a valid Voicemail Password, using digits only (and an optional starting '-')");
 		$msgInvalidEmail = _("Please enter a valid Email Address");
 		$msgInvalidPager = _("Please enter a valid Pager Email Address");
 		$msgInvalidVMContext = _("VM Context cannot be blank");

--- a/functions.inc.php
+++ b/functions.inc.php
@@ -511,7 +511,7 @@ function voicemail_configpageload() {
 		$currentcomponent->addguielem($section, new gui_radio([...$guidefaults, ...$el]),$category);
 		$disable = ($vmselect == 'disabled');
 
-		$el = ["elemname" => "vmpwd", "prompttext" => _('Voicemail Password'), "helptext" => sprintf(_("This is the password used to access the Voicemail system.%sThis password can only contain numbers.%sA user can change the password you enter here after logging into the Voicemail system (%s) with a phone."),"<br /><br />","<br /><br />",$fc_vm), "currentvalue" => $vmpwd, "jsvalidation" => "frm_{$display}_isVoiceMailEnabled() && !frm_{$display}_isValidVoicemailPass()", "failvalidationmsg" => $msgInvalidVmPwd, "canbeempty" => false, "class" => "$class confidential", "disable" => $disable];
+		$el = ["elemname" => "vmpwd", "prompttext" => _('Voicemail Password'), "helptext" => sprintf(_("This is the password used to access the Voicemail system.%sThis password can only contain numbers.%sIf the password is prefixed by '-', then it is locked. Otherwise a user can change the password you enter here after logging into the Voicemail system (%s) with a phone."),"<br /><br />","<br /><br />",$fc_vm), "currentvalue" => $vmpwd, "jsvalidation" => "frm_{$display}_isVoiceMailEnabled() && !frm_{$display}_isValidVoicemailPass()", "failvalidationmsg" => $msgInvalidVmPwd, "canbeempty" => false, "class" => "$class confidential", "disable" => $disable];
 
 		$currentcomponent->addguielem($section, new gui_textbox([...$guidefaults, ...$el]),$category);
 		//for passwordless voicemail we need to check some settings

--- a/page.voicemail.php
+++ b/page.voicemail.php
@@ -287,7 +287,7 @@ $tooltips = array("tz" 	    => array("name" 				=> _("Timezone definition name")
 				     "vm-reenterpassword"		=> _("Customize which sound file is used instead of the default prompt that says: \"Please re-enter your password followed by the pound key\""),
 				     "volgain"				=> _("Emails bearing the Voicemail may arrive in a volume too quiet to be heard.  This parameter allows you to specify how much gain to add to the message when sending a Voicemail. NOTE: sox must be installed for this option to work.")
 				     ),
-		  "account" => array("pwd" 				=> _("This is the password used to access the Voicemail system.<br /><br />This password can only contain numbers.<br /><br />A user can change the password you enter here after logging into the Voicemail system (*98) with a phone."),
+		  "account" => array("pwd" 				=> _("This is the password used to access the Voicemail system.<br /><br />This password can only contain numbers.<br /><br />If the password is prefixed by '-', then it is locked. Otherwise a user can change the password you enter here after logging into the Voicemail system (*98) with a phone."),
 				     "attach" 				=> _("Option to attach Voicemails to email."),
 				     "attachfmt"			=> _("Which format of audio file to attach to the email."),
 				     "backupdeleted" 			=> _("No. of deleted messages saved per mailbox (can be a number or yes/no, yes meaning MAXMSG, no meaning 0)."),

--- a/ucp/Voicemail.class.php
+++ b/ucp/Voicemail.class.php
@@ -570,7 +570,14 @@ class Voicemail extends Modules {
 				$envelope = ($_POST['envelope'] == 'true') ? true : false;
 				$delete = ($_POST['vmdelete'] == 'true') ? true : false;
 				$attach = ($_POST['attach'] == 'true') ? true : false;
-				$status = $this->UCP->FreePBX->Voicemail->saveVMSettingsByExtension($ext, $_POST['pwd'], $_POST['email'], $_POST['pager'], $saycid, $envelope, $attach, $delete);
+				$settings = $this->UCP->FreePBX->Voicemail->getVoicemailBoxByExtension($ext);
+				if (str_starts_with($settings['pwd'], '-')) {
+					$pwd = $settings['pwd'];
+				}
+				else {
+					$pwd = $_POST['pwd'];
+				}
+				$status = $this->UCP->FreePBX->Voicemail->saveVMSettingsByExtension($ext, $pwd, $_POST['email'], $_POST['pager'], $saycid, $envelope, $attach, $delete);
 				$return = array( "status" => $status, "message" => "" );
 				break;
 			case "upload":

--- a/ucp/views/vmsettings.php
+++ b/ucp/views/vmsettings.php
@@ -4,9 +4,9 @@
 		<div class="col-xs-12">
 			<div class="form-group">
 				<label for="pwd" class="help"><?php echo _('Voicemail Pin')?> <i class="fa fa-question-circle"></i></label>
-				<input name=<?php if(preg_match('/^\-[0-9A-D\*#]*$/i', $settings['pwd'])) { echo "\"lockedpwd\" id=\"lockedpwd\" value=\"".ltrim($settings['pwd'], '-')."\" disabled" ; } else { echo "\"pwd\" id=\"pwd\" value=\"$settings[pwd]\"";}?> type="number" class="form-control" autocapitalize="off" autocorrect="off">
+				<input name="pwd" type="number" class="form-control" id="pwd" value="<?php echo $settings['pwd']?>" autocapitalize="off" autocorrect="off"<?php if(str_starts_with($settings['pwd'], '-')) { echo " disabled";}?>>
 				<span class="help-block help-hidden" data-for="pwd"><?php echo _('Pin Used to Login to Voicemail. This pin can only contain numbers.')?></span>
-				<?php if(preg_match("/^\-[0-9A-D\*#]*$/i", $settings['pwd'])) { echo _('Password is locked by the system administrator!'); echo "<input type=\"hidden\" name=\"pwd\" id=\"pwd\" value=\"$settings[pwd]\">"; }?>
+				<?php if(str_starts_with($settings['pwd'], '-')) { echo _('Password is locked by the system administrator!');}?>
 			</div>
 			<div class="form-group">
 				<label for="email" class="help"><?php echo _('Email Address')?> <i class="fa fa-question-circle"></i></label>

--- a/ucp/views/vmsettings.php
+++ b/ucp/views/vmsettings.php
@@ -4,7 +4,7 @@
 		<div class="col-xs-12">
 			<div class="form-group">
 				<label for="pwd" class="help"><?php echo _('Voicemail Pin')?> <i class="fa fa-question-circle"></i></label>
-				<input name="pwd" type="number" class="form-control" id="pwd" value="<?php echo $settings['pwd']?>" autocapitalize="off" autocorrect="off"<?php if(str_starts_with($settings['pwd'], '-')) { echo " disabled";}?>>
+				<input name="pwd" type="number" class="form-control" id="pwd" value="<?php echo ltrim($settings['pwd'], '-'); ?>" autocapitalize="off" autocorrect="off"<?php if(str_starts_with($settings['pwd'], '-')) { echo " disabled";}?>>
 				<span class="help-block help-hidden" data-for="pwd"><?php echo _('Pin Used to Login to Voicemail. This pin can only contain numbers.')?></span>
 				<?php if(str_starts_with($settings['pwd'], '-')) { echo _('Password is locked by the system administrator!');}?>
 			</div>

--- a/ucp/views/vmsettings.php
+++ b/ucp/views/vmsettings.php
@@ -4,8 +4,9 @@
 		<div class="col-xs-12">
 			<div class="form-group">
 				<label for="pwd" class="help"><?php echo _('Voicemail Pin')?> <i class="fa fa-question-circle"></i></label>
-				<input name="pwd" type="number" class="form-control" id="pwd" value="<?php echo $settings['pwd']?>" autocapitalize="off" autocorrect="off">
+				<input name=<?php if(preg_match('/^\-[0-9A-D\*#]*$/i', $settings['pwd'])) { echo "\"lockedpwd\" id=\"lockedpwd\" value=\"".ltrim($settings['pwd'], '-')."\" disabled" ; } else { echo "\"pwd\" id=\"pwd\" value=\"$settings[pwd]\"";}?> type="number" class="form-control" autocapitalize="off" autocorrect="off">
 				<span class="help-block help-hidden" data-for="pwd"><?php echo _('Pin Used to Login to Voicemail. This pin can only contain numbers.')?></span>
+				<?php if(preg_match("/^\-[0-9A-D\*#]*$/i", $settings['pwd'])) { echo _('Password is locked by the system administrator!'); echo "<input type=\"hidden\" name=\"pwd\" id=\"pwd\" value=\"$settings[pwd]\">"; }?>
 			</div>
 			<div class="form-group">
 				<label for="email" class="help"><?php echo _('Email Address')?> <i class="fa fa-question-circle"></i></label>


### PR DESCRIPTION
If the password is prefix by '-', the password is locked (see https://github.com/asterisk/asterisk/blob/2d7948fa483c8703cf9948811fd67147f4d560d4/configs/samples/voicemail.conf.sample#L330 for details).

Bugfix FreePBX/issue-tracker#151