### PR TITLE
Add console block to module.xml

### DIFF
--- a/module.xml
+++ b/module.xml
@@ -108,4 +108,10 @@
 			<field name="value" type="string" length="80" default=""/>
 		</table>
 	</database>
+	<console>
+		<command>
+			<name>voicemail</name>
+			<class>Voicemail</class>
+		</command>
+    </console>
 </module>


### PR DESCRIPTION
This PR add  the console block to the file module.xml to prevent the message "Deprecated way to add Console commands for module" for FreePBX 16

Bugfix FreePBX/issue-tracker#278