### PR TITLE
don't try creating existing directories

### DIFF
--- a/Restore.php
+++ b/Restore.php
@@ -15,7 +15,9 @@ class Restore Extends Base\RestoreBase{
 				$source = $this->tmpdir.'/files'.$file->getPathTo().'/'.$file->getFilename();
 				$dest = $filename;
 				if(file_exists($source)){
-					@mkdir($file->getPathTo(),0755,true);
+					if (!file_exists($file->getPathTo())) {
+						mkdir($file->getPathTo(),0755,true);
+					}
 					copy($source, $dest);
 					$nfiles++;
 				}

--- a/install.php
+++ b/install.php
@@ -60,7 +60,7 @@ if(!empty($globals_convert)) {
   }
 }
 
-$freepbx_conf =& freepbx_conf::create();
+$freepbx_conf = freepbx_conf::create();
 
 // VM_SHOW_IMAP
 //


### PR DESCRIPTION
The error suppression operator doesn't seem to be working, and is terrible practice anyway. This change prevents warnings showing up in the restore output:
```none
PHP Warning: mkdir(): File exists in /var/www/html/admin/modules/voicemail/Restore.php on line 18

PHP Warning: mkdir(): File exists in /var/www/html/admin/modules/voicemail/Restore.php on line 18

PHP Warning: mkdir(): File exists in /var/www/html/admin/modules/voicemail/Restore.php on line 18

PHP Warning: mkdir(): File exists in /var/www/html/admin/modules/voicemail/Restore.php on line 18

PHP Warning: mkdir(): File exists in /var/www/html/admin/modules/voicemail/Restore.php on line 18

PHP Warning: mkdir(): File exists in /var/www/html/admin/modules/voicemail/Restore.php on line 18

PHP Warning: mkdir(): File exists in /var/www/html/admin/modules/voicemail/Restore.php on line 18

PHP Warning: mkdir(): File exists in /var/www/html/admin/modules/voicemail/Restore.php on line 18
```